### PR TITLE
fix: replace MySQL-specific JSON_EXTRACT with database-agnostic JSON queries (#30)

### DIFF
--- a/src/Services/AgentHealthScorer.php
+++ b/src/Services/AgentHealthScorer.php
@@ -3,11 +3,13 @@
 namespace Ashrafic\AiOrbit\Services;
 
 use Ashrafic\AiOrbit\Services\Concerns\UsesAiConnection;
+use Ashrafic\AiOrbit\Services\Concerns\UsesJsonQueries;
 use Illuminate\Support\Collection;
 
 class AgentHealthScorer
 {
     use UsesAiConnection;
+    use UsesJsonQueries;
 
     /**
      * Calculate health score (0-100) for a given agent.
@@ -41,7 +43,7 @@ class AgentHealthScorer
             ->where('created_at', '>=', $dateFrom)
             ->where(function ($q) {
                 $q->where('role', 'tool')
-                    ->orWhereRaw("JSON_EXTRACT(meta, '$.error') IS NOT NULL");
+                    ->orWhereRaw($this->jsonExpr('meta', 'error').' IS NOT NULL');
             })
             ->count();
 
@@ -53,7 +55,7 @@ class AgentHealthScorer
             $tokenData = $this->connection()->table('agent_conversation_messages')
                 ->where('agent', $agentClass)
                 ->where('created_at', '>=', $dateFrom)
-                ->selectRaw('AVG(JSON_EXTRACT(`usage`, "$.prompt_tokens") + JSON_EXTRACT(`usage`, "$.completion_tokens")) as avg')
+                ->selectRaw('AVG('.$this->jsonExprNumeric('usage', 'prompt_tokens').' + '.$this->jsonExprNumeric('usage', 'completion_tokens').') as avg')
                 ->first();
 
             $avgTokens = (int) ($tokenData->avg ?? 0);

--- a/src/Services/BudgetMonitor.php
+++ b/src/Services/BudgetMonitor.php
@@ -6,6 +6,7 @@ use Ashrafic\AiOrbit\Models\AiRun;
 use Ashrafic\AiOrbit\Models\BudgetAlert;
 use Ashrafic\AiOrbit\Notifications\BudgetExceeded;
 use Ashrafic\AiOrbit\Services\Concerns\UsesAiConnection;
+use Ashrafic\AiOrbit\Services\Concerns\UsesJsonQueries;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Notification;
@@ -14,6 +15,7 @@ use Illuminate\Support\Facades\Schema;
 class BudgetMonitor
 {
     use UsesAiConnection;
+    use UsesJsonQueries;
 
     public function __construct(
         private readonly CostCalculator $costCalculator,
@@ -175,17 +177,17 @@ class BudgetMonitor
             return 0.0;
         }
 
-        $jsonProvider = "REPLACE(JSON_EXTRACT(meta, '$.provider'), '\"', '')";
-        $jsonModel = "REPLACE(JSON_EXTRACT(meta, '$.model'), '\"', '')";
+        $provider = $this->jsonExpr('meta', 'provider');
+        $model = $this->jsonExpr('meta', 'model');
 
         $rows = $this->connection()->table('agent_conversation_messages')
             ->where('created_at', '>=', $this->periodStart($period))
-            ->selectRaw("{$jsonProvider} as provider")
-            ->selectRaw("{$jsonModel} as model")
-            ->selectRaw("COALESCE(SUM(JSON_EXTRACT(`usage`, '$.prompt_tokens')), 0) as input_tokens")
-            ->selectRaw("COALESCE(SUM(JSON_EXTRACT(`usage`, '$.completion_tokens')), 0) as output_tokens")
-            ->groupByRaw($jsonProvider)
-            ->groupByRaw($jsonModel)
+            ->selectRaw("{$provider} as provider")
+            ->selectRaw("{$model} as model")
+            ->addSelect($this->jsonSum('usage', 'prompt_tokens', 'input_tokens'))
+            ->addSelect($this->jsonSum('usage', 'completion_tokens', 'output_tokens'))
+            ->groupByRaw($provider)
+            ->groupByRaw($model)
             ->get();
 
         return (float) $rows->sum(function (object $row): float {

--- a/src/Services/Concerns/UsesJsonQueries.php
+++ b/src/Services/Concerns/UsesJsonQueries.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Ashrafic\AiOrbit\Services\Concerns;
+
+use Illuminate\Contracts\Database\Query\Expression;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Grammars\Grammar;
+
+trait UsesJsonQueries
+{
+    /**
+     * Get a compiled SQL expression for a JSON path (for use in raw aggregates).
+     *
+     * Calls the query grammar's wrapJsonSelector() to produce per-driver SQL:
+     *   MySQL:     json_unquote(json_extract(`col`, '$."key"'))
+     *   PostgreSQL: "col"->>'key'
+     *   SQLite:    json_extract("col", '$."key"')
+     *   SQL Server: json_value("col", '$."key"')
+     */
+    protected function jsonExpr(string $column, string $path): string
+    {
+        $expr = \Closure::bind(
+            fn (string $selector): string => $this->wrapJsonSelector($selector),
+            $this->grammar(),
+            Grammar::class,
+        )("{$column}->{$path}");
+
+        if ($this->driverName() === 'pgsql') {
+            $pos = strpos($expr, '->');
+            if ($pos !== false) {
+                $expr = substr($expr, 0, $pos).'::jsonb'.substr($expr, $pos);
+            }
+        }
+
+        return $expr;
+    }
+
+    /**
+     * Like jsonExpr() but with explicit numeric casts for SUM/AVG on
+     * PostgreSQL and SQL Server.
+     */
+    protected function jsonExprNumeric(string $column, string $path): string
+    {
+        $expr = $this->jsonExpr($column, $path);
+
+        return match ($this->driverName()) {
+            'pgsql' => "({$expr})::numeric",
+            'sqlsrv' => "CAST({$expr} AS FLOAT)",
+            default => $expr,
+        };
+    }
+
+    /**
+     * Build a portable COALESCE(SUM(json_numeric), 0) expression.
+     *
+     * @return Expression
+     */
+    protected function jsonSum(string $column, string $path, string $alias)
+    {
+        return $this->connection()->raw(
+            'COALESCE(SUM('.$this->jsonExprNumeric($column, $path).'), 0) as '.$alias
+        );
+    }
+
+    /**
+     * Build a portable AVG(json_numeric) expression.
+     *
+     * @return Expression
+     */
+    protected function jsonAvg(string $column, string $path, string $alias)
+    {
+        return $this->connection()->raw(
+            'AVG('.$this->jsonExprNumeric($column, $path).') as '.$alias
+        );
+    }
+
+    /**
+     * Get the query grammar for the configured connection.
+     */
+    private function grammar(): Grammar
+    {
+        $connection = $this->connection();
+
+        /** @var Connection $connection */
+        return $connection->getQueryGrammar();
+    }
+
+    /**
+     * Get the driver name for the configured connection.
+     */
+    private function driverName(): string
+    {
+        $connection = $this->connection();
+
+        /** @var Connection $connection */
+        return $connection->getDriverName();
+    }
+}

--- a/src/Services/ConversationRepository.php
+++ b/src/Services/ConversationRepository.php
@@ -3,12 +3,14 @@
 namespace Ashrafic\AiOrbit\Services;
 
 use Ashrafic\AiOrbit\Services\Concerns\UsesAiConnection;
+use Ashrafic\AiOrbit\Services\Concerns\UsesJsonQueries;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 
 class ConversationRepository
 {
     use UsesAiConnection;
+    use UsesJsonQueries;
 
     /**
      * Get a paginated list of conversations with optional filters.
@@ -30,7 +32,7 @@ class ConversationRepository
                 'agent_conversations.created_at',
                 'agent_conversations.updated_at',
             ])
-            ->where('agent_conversations.user_id', '>', 0);
+            ->where('agent_conversations.user_id', '>=', 0);
 
         if ($this->hasTable('agent_conversation_messages')) {
             $query->selectRaw('COUNT(agent_conversation_messages.id) as message_count');
@@ -43,10 +45,10 @@ class ConversationRepository
 
             if ($this->hasColumn('agent_conversation_messages', 'usage')) {
                 $query->addSelect(
-                    $this->connection()->raw("COALESCE(SUM(JSON_EXTRACT(agent_conversation_messages.usage, '$.prompt_tokens')), 0) as total_input_tokens")
+                    $this->jsonSum('agent_conversation_messages.usage', 'prompt_tokens', 'total_input_tokens')
                 );
                 $query->addSelect(
-                    $this->connection()->raw("COALESCE(SUM(JSON_EXTRACT(agent_conversation_messages.usage, '$.completion_tokens')), 0) as total_output_tokens")
+                    $this->jsonSum('agent_conversation_messages.usage', 'completion_tokens', 'total_output_tokens')
                 );
             }
 

--- a/src/Services/ProviderHealthChecker.php
+++ b/src/Services/ProviderHealthChecker.php
@@ -4,6 +4,7 @@ namespace Ashrafic\AiOrbit\Services;
 
 use Ashrafic\AiOrbit\Models\AiRun;
 use Ashrafic\AiOrbit\Services\Concerns\UsesAiConnection;
+use Ashrafic\AiOrbit\Services\Concerns\UsesJsonQueries;
 use Carbon\CarbonInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -12,6 +13,7 @@ use Illuminate\Support\Facades\Schema;
 class ProviderHealthChecker
 {
     use UsesAiConnection;
+    use UsesJsonQueries;
 
     /**
      * Get health metrics per provider, merging data from both AiRuns
@@ -111,16 +113,18 @@ class ProviderHealthChecker
             return collect();
         }
 
-        $jsonProvider = "REPLACE(JSON_EXTRACT(meta, '\$.provider'), '\"', '')";
+        $providerExpr = $this->jsonExpr('meta', 'provider');
+        $errorExpr = $this->jsonExpr('meta', 'error');
+        $latencyExpr = $this->jsonExpr('meta', 'latency_ms');
 
         $providers = $this->connection()->table('agent_conversation_messages')
             ->where('created_at', '>=', $dateFrom)
             ->whereNotNull('meta')
-            ->whereRaw($jsonProvider.' IS NOT NULL')
-            ->whereRaw($jsonProvider." != ''")
-            ->selectRaw($jsonProvider.' as provider')
+            ->whereRaw("{$providerExpr} IS NOT NULL")
+            ->whereRaw("{$providerExpr} != ''")
+            ->selectRaw("{$providerExpr} as provider")
             ->selectRaw('COUNT(*) as total')
-            ->groupBy($this->connection()->raw($jsonProvider))
+            ->groupByRaw($providerExpr)
             ->get();
 
         $results = collect();
@@ -136,29 +140,29 @@ class ProviderHealthChecker
 
             $errorCount = $this->connection()->table('agent_conversation_messages')
                 ->where('created_at', '>=', $dateFrom)
-                ->whereRaw($jsonProvider.' = ?', [$provider])
-                ->where(function ($q) {
+                ->whereRaw("{$providerExpr} = ?", [$provider])
+                ->where(function ($q) use ($errorExpr) {
                     $q->where('role', 'tool')
-                        ->orWhereRaw("JSON_EXTRACT(meta, '$.error') IS NOT NULL");
+                        ->orWhereRaw("{$errorExpr} IS NOT NULL");
                 })
                 ->count();
 
             $rateLimitCount = $this->connection()->table('agent_conversation_messages')
                 ->where('created_at', '>=', $dateFrom)
-                ->whereRaw($jsonProvider.' = ?', [$provider])
-                ->where(function ($q) {
-                    $q->whereRaw("JSON_EXTRACT(meta, '$.error') LIKE '%rate limit%'")
-                        ->orWhereRaw("JSON_EXTRACT(meta, '$.error') LIKE '%429%'")
-                        ->orWhereRaw("JSON_EXTRACT(meta, '$.error') LIKE '%too many%'");
+                ->whereRaw("{$providerExpr} = ?", [$provider])
+                ->where(function ($q) use ($errorExpr) {
+                    $q->whereRaw("{$errorExpr} LIKE '%rate limit%'")
+                        ->orWhereRaw("{$errorExpr} LIKE '%429%'")
+                        ->orWhereRaw("{$errorExpr} LIKE '%too many%'");
                 })
                 ->count();
 
             $avgLatency = 0;
             $latencyData = $this->connection()->table('agent_conversation_messages')
                 ->where('created_at', '>=', $dateFrom)
-                ->whereRaw($jsonProvider.' = ?', [$provider])
-                ->whereRaw("JSON_EXTRACT(meta, '$.latency_ms') IS NOT NULL")
-                ->selectRaw("AVG(JSON_EXTRACT(meta, '$.latency_ms')) as avg_ms")
+                ->whereRaw("{$providerExpr} = ?", [$provider])
+                ->whereRaw("{$latencyExpr} IS NOT NULL")
+                ->select($this->jsonAvg('meta', 'latency_ms', 'avg_ms'))
                 ->first();
 
             if ($latencyData && isset($latencyData->avg_ms)) {

--- a/src/Services/TokenAggregator.php
+++ b/src/Services/TokenAggregator.php
@@ -4,6 +4,7 @@ namespace Ashrafic\AiOrbit\Services;
 
 use Ashrafic\AiOrbit\Models\AiRun;
 use Ashrafic\AiOrbit\Services\Concerns\UsesAiConnection;
+use Ashrafic\AiOrbit\Services\Concerns\UsesJsonQueries;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder;
@@ -14,6 +15,7 @@ use Illuminate\Support\Facades\Schema;
 class TokenAggregator
 {
     use UsesAiConnection;
+    use UsesJsonQueries;
 
     /**
      * Get token usage statistics for a given time period.
@@ -139,8 +141,8 @@ class TokenAggregator
 
         if ($this->hasTable('agent_conversation_messages') && $this->hasColumn('agent_conversation_messages', 'usage')) {
             $selects = [
-                $this->connection()->raw("COALESCE(SUM(JSON_EXTRACT(`usage`, '$.prompt_tokens')), 0) as input_tokens"),
-                $this->connection()->raw("COALESCE(SUM(JSON_EXTRACT(`usage`, '$.completion_tokens')), 0) as output_tokens"),
+                $this->jsonSum('usage', 'prompt_tokens', 'input_tokens'),
+                $this->jsonSum('usage', 'completion_tokens', 'output_tokens'),
             ];
 
             $tokenData = $this->applyDateFilter(
@@ -172,7 +174,7 @@ class TokenAggregator
                     $this->connection()->table('agent_conversation_messages'), 'created_at', $from, $to
                 )
                     ->select($this->connection()->raw(
-                        "COUNT(DISTINCT JSON_EXTRACT(meta, '$.provider')) as provider_count"
+                        'COUNT(DISTINCT '.$this->jsonExpr('meta', 'provider').') as provider_count'
                     ))
                     ->first();
 
@@ -336,11 +338,11 @@ class TokenAggregator
         $hasAgent = $this->hasColumn('agent_conversation_messages', 'agent');
         $hasMeta = $this->hasColumn('agent_conversation_messages', 'meta');
 
-        $jsonVal = fn (string $path): string => "REPLACE(JSON_EXTRACT(meta, '{$path}'), '\"', '')";
+        $jsonVal = fn (string $key): string => $this->jsonExpr('meta', $key);
 
         $groupColumn = match ($groupBy) {
-            'model' => $hasMeta ? $jsonVal('$.model') : null,
-            'provider' => $hasMeta ? $jsonVal('$.provider') : null,
+            'model' => $hasMeta ? $jsonVal('model') : null,
+            'provider' => $hasMeta ? $jsonVal('provider') : null,
             default => $hasAgent ? 'agent' : null,
         };
 
@@ -354,14 +356,16 @@ class TokenAggregator
         ];
 
         if ($hasMeta) {
-            $selects[] = $this->connection()->raw("COALESCE(MIN({$jsonVal('$.model')}), 'unknown') as model");
-            $selects[] = $this->connection()->raw("COALESCE(MIN({$jsonVal('$.provider')}), 'unknown') as provider");
+            $selects[] = $this->connection()->raw("COALESCE(MIN({$jsonVal('model')}), 'unknown') as model");
+            $selects[] = $this->connection()->raw("COALESCE(MIN({$jsonVal('provider')}), 'unknown') as provider");
         }
 
         if ($this->hasColumn('agent_conversation_messages', 'usage')) {
-            $selects[] = $this->connection()->raw("COALESCE(SUM(JSON_EXTRACT(`usage`, '$.prompt_tokens')), 0) as input_tokens");
-            $selects[] = $this->connection()->raw("COALESCE(SUM(JSON_EXTRACT(`usage`, '$.completion_tokens')), 0) as output_tokens");
-            $selects[] = $this->connection()->raw("COALESCE(SUM(JSON_EXTRACT(`usage`, '$.prompt_tokens')), 0) + COALESCE(SUM(JSON_EXTRACT(`usage`, '$.completion_tokens')), 0) as total");
+            $selects[] = $this->jsonSum('usage', 'prompt_tokens', 'input_tokens');
+            $selects[] = $this->jsonSum('usage', 'completion_tokens', 'output_tokens');
+            $selects[] = $this->connection()->raw(
+                'COALESCE(SUM('.$this->jsonExprNumeric('usage', 'prompt_tokens').'), 0) + COALESCE(SUM('.$this->jsonExprNumeric('usage', 'completion_tokens').'), 0) as total'
+            );
         }
 
         $result = $this->applyDateFilter(


### PR DESCRIPTION
Closes #30 

## Summary

Replaces MySQL-specific `JSON_EXTRACT` calls, backtick quoting, and `REPLACE()` string extraction with a portable `UsesJsonQueries` trait that compiles per-driver JSON expressions via the Laravel query grammar.

## Problem

Code uses raw MySQL-specific syntax for JSON manipulation which crashes on PostgreSQL:

```
ERROR: operator does not exist: text ->> unknown
ERROR: function json_extract does not exist
```

## Solution

- **New trait** `UsesJsonQueries` with `jsonExpr()`, `jsonExprNumeric()`, `jsonSum()`, `jsonAvg()` helpers that call the grammar's `wrapJsonSelector()` to compile per-driver SQL
- PostgreSQL gets `::jsonb` cast for TEXT columns, `::numeric` cast for aggregates
- SQL Server gets `CAST AS FLOAT` for numeric aggregates
- MySQL and SQLite need no explicit casts

### Per-driver output examples

| Driver | `jsonExpr('meta', 'provider')` |
|--------|----------------------------------|
| MySQL | `json_unquote(json_extract(...))` |
| PostgreSQL | `"meta"::jsonb->>'provider'` |
| SQLite | `json_extract(...)` |
| SQL Server | `json_value(...)` |

## Files changed

| File | Change |
|------|--------|
| `src/Services/Concerns/UsesJsonQueries.php` | New trait |
| `src/Services/BudgetMonitor.php` | JSON_EXTRACT → trait |
| `src/Services/TokenAggregator.php` | 8 JSON_EXTRACT replacements |
| `src/Services/AgentHealthScorer.php` | orWhereRaw → trait |
| `src/Services/ProviderHealthChecker.php` | All JSON WHERE/SELECT/GROUP BY ported |
| `src/Services/ConversationRepository.php` | JSON_EXTRACT sums + user_id >= 0 fix |

## Verified

- 84 tests passing (Pest)
- Pint code style passing (81 files)
- PHPStan level 8 passing (0 errors)
- Tested against MySQL and PostgreSQL